### PR TITLE
Use invoice_partner_display_name for invoice client

### DIFF
--- a/odoo_connection.py
+++ b/odoo_connection.py
@@ -94,7 +94,7 @@ class OdooConnection:
                 {
                     'fields': [
                         'name', 'invoice_date', 'amount_total', 'amount_residual',
-                        'payment_state', 'partner_id', 'invoice_user_id'
+                        'payment_state', 'invoice_partner_display_name', 'invoice_user_id'
                     ]
                 }
             )
@@ -106,7 +106,7 @@ class OdooConnection:
                     'id': factura['id'],
                     'nombre': factura['name'],
                     'fecha': factura['invoice_date'].strftime('%d/%m/%Y') if factura['invoice_date'] else '',
-                    'cliente': factura['partner_id'][1] if factura['partner_id'] else 'Sin cliente',
+                    'cliente': factura.get('invoice_partner_display_name', 'Sin cliente'),
                     'total': factura['amount_total'],
                     'pendiente': factura['amount_residual'],
                     'estado': estado_pago,
@@ -143,7 +143,7 @@ class OdooConnection:
                 {
                     'fields': [
                         'name', 'invoice_date', 'amount_total', 'amount_residual',
-                        'payment_state', 'partner_id'
+                        'payment_state', 'invoice_partner_display_name'
                     ]
                 }
             )
@@ -157,7 +157,7 @@ class OdooConnection:
                     'id': factura['id'],
                     'nombre': factura['name'],
                     'fecha': factura['invoice_date'].strftime('%d/%m/%Y') if factura['invoice_date'] else '',
-                    'cliente': factura['partner_id'][1] if factura['partner_id'] else 'Sin cliente',
+                    'cliente': factura.get('invoice_partner_display_name', 'Sin cliente'),
                     'total': factura['amount_total'],
                     'pendiente': factura['amount_residual'],
                     'estado': estado_pago,


### PR DESCRIPTION
## Summary
- Retrieve invoice_partner_display_name when loading vendor invoices
- Show invoice partner's display name as client in filtered invoice search results

## Testing
- `python -m py_compile odoo_connection.py app.py`


------
https://chatgpt.com/codex/tasks/task_b_68bad9f82fcc832fb763bb9025280871