### PR TITLE
Fix invoice PDF retrieval using new XMLID API

### DIFF
--- a/odoo_connection.py
+++ b/odoo_connection.py
@@ -337,12 +337,12 @@ class OdooConnection:
     def get_factura_pdf(self, factura_id):
         """Obtener el PDF de una factura"""
         try:
-            report_id = self.models.execute_kw(
+            report_model, report_id = self.models.execute_kw(
                 self.db,
                 self.uid,
                 self.password,
                 'ir.model.data',
-                'xmlid_to_res_id',
+                'xmlid_to_res_model_res_id',
                 ['account.report_invoice'],
             )
             pdf = self.models.execute_kw(
@@ -351,7 +351,7 @@ class OdooConnection:
                 self.password,
                 'ir.actions.report',
                 '_render_qweb_pdf',
-                [[report_id], [factura_id]],
+                [report_id, [factura_id]],
             )
             if isinstance(pdf, dict) and pdf.get('result'):
                 pdf_content = pdf['result']


### PR DESCRIPTION
## Summary
- update `get_factura_pdf` to use `xmlid_to_res_model_res_id`
- correct arguments when rendering QWeb PDF

## Testing
- `python -m py_compile app.py odoo_connection.py`


------
https://chatgpt.com/codex/tasks/task_b_68baef7f14b0832f831fa6a969442b8a