### PR TITLE
Mostrar deuda y saldo a favor por cliente

### DIFF
--- a/templates/cliente_detalle.html
+++ b/templates/cliente_detalle.html
@@ -23,6 +23,16 @@
                     <i class="fas fa-user me-2"></i>{{ cliente.nombre }}
                 </h5>
                 <div class="mt-2">
+                    <p class="mb-1">
+                        <i class="fas fa-money-bill-wave me-2 text-danger"></i>
+                        Deuda total: ${{ '%.2f'|format(cliente.deuda_total) }}
+                    </p>
+                    {% if cliente.saldo_favor > 0 %}
+                    <p class="mb-1">
+                        <i class="fas fa-coins me-2 text-success"></i>
+                        Saldo a favor: ${{ '%.2f'|format(cliente.saldo_favor) }}
+                    </p>
+                    {% endif %}
                     {% if cliente.email %}
                     <p class="mb-1">
                         <i class="fas fa-envelope me-2 text-muted"></i>{{ cliente.email }}

--- a/templates/clientes.html
+++ b/templates/clientes.html
@@ -49,6 +49,16 @@
                             <h5 class="fw-bold text-primary">
                                 <i class="fas fa-user me-2"></i>{{ cliente.nombre }}
                             </h5>
+                            <p class="mb-1">
+                                <i class="fas fa-money-bill-wave me-2 text-danger"></i>
+                                Deuda total: ${{ '%.2f'|format(cliente.deuda_total) }}
+                            </p>
+                            {% if cliente.saldo_favor > 0 %}
+                            <p class="mb-0">
+                                <i class="fas fa-coins me-2 text-success"></i>
+                                Saldo a favor: ${{ '%.2f'|format(cliente.saldo_favor) }}
+                            </p>
+                            {% endif %}
                         </div>
                     </div>
                 </a>
@@ -107,6 +117,15 @@ function actualizarListaClientes(clientes) {
                     <h5 class="fw-bold text-primary">
                         <i class="fas fa-user me-2"></i>${c.nombre}
                     </h5>
+                    <p class="mb-1">
+                        <i class="fas fa-money-bill-wave me-2 text-danger"></i>
+                        Deuda total: $${c.deuda_total.toFixed(2)}
+                    </p>
+                    ${c.saldo_favor > 0 ? `
+                    <p class="mb-0">
+                        <i class="fas fa-coins me-2 text-success"></i>
+                        Saldo a favor: $${c.saldo_favor.toFixed(2)}
+                    </p>` : ''}
                 </div>
             </div>
         </a>


### PR DESCRIPTION
## Summary
- muestra deuda total y saldo a favor para cada cliente tanto en la lista como en la ficha de detalle
- usa los campos `credit` y `debit` de Odoo para calcular montos pendientes y saldos a favor

## Testing
- `python -m py_compile app.py odoo_connection.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68baf265a494832fa7b75600db7a9d59