### PR TITLE
Fallback to xmlid_to_res_id for invoice report

### DIFF
--- a/odoo_connection.py
+++ b/odoo_connection.py
@@ -408,14 +408,24 @@ class OdooConnection:
     def get_factura_pdf(self, factura_id):
         """Obtener el PDF de una factura"""
         try:
-            report_model, report_id = self.models.execute_kw(
-                self.db,
-                self.uid,
-                self.password,
-                'ir.model.data',
-                'xmlid_to_res_model_res_id',
-                ['account.report_invoice'],
-            )
+            try:
+                _, report_id = self.models.execute_kw(
+                    self.db,
+                    self.uid,
+                    self.password,
+                    'ir.model.data',
+                    'xmlid_to_res_model_res_id',
+                    ['account.report_invoice'],
+                )
+            except Exception:
+                report_id = self.models.execute_kw(
+                    self.db,
+                    self.uid,
+                    self.password,
+                    'ir.model.data',
+                    'xmlid_to_res_id',
+                    ['account.report_invoice'],
+                )
             pdf = self.models.execute_kw(
                 self.db,
                 self.uid,


### PR DESCRIPTION
## Summary
- gracefully fall back to `xmlid_to_res_id` when `xmlid_to_res_model_res_id` is unavailable for invoice PDF generation

## Testing
- `python -m py_compile odoo_connection.py app.py`


------
https://chatgpt.com/codex/tasks/task_b_68baf6282fe4832f8a1ff9a28181b027