### PR TITLE
Optimize client search to load faster

### DIFF
--- a/app.py
+++ b/app.py
@@ -166,13 +166,14 @@ def api_buscar_clientes():
         return jsonify({'error': 'No autorizado'}), 401
 
     nombre_cliente = request.args.get('nombre', '')
+    limite = request.args.get('limite', 20)
 
     try:
         odoo = OdooConnection(ODOO_CONFIG['url'], ODOO_CONFIG['db'],
                               session['username'], session['password'])
         odoo.uid = session['user_id']
 
-        clientes = odoo.buscar_clientes(nombre_cliente)
+        clientes = odoo.buscar_clientes(nombre_cliente, limit=int(limite))
         return jsonify(clientes)
     except Exception as e:
         return jsonify({'error': str(e)}), 500

--- a/templates/clientes.html
+++ b/templates/clientes.html
@@ -51,7 +51,9 @@ function buscarClientes() {
     const nombreCliente = document.getElementById('buscarCliente').value;
     mostrarLoading();
     const params = new URLSearchParams();
+    const limite = 20;
     if (nombreCliente) params.append('nombre', nombreCliente);
+    params.append('limite', limite);
     fetch(`/api/buscar-clientes?${params.toString()}`)
         .then(response => response.json())
         .then(data => {


### PR DESCRIPTION
## Summary
- Limit client search results in `buscar_clientes` using `search_read` with a configurable limit
- Expose `limite` query parameter in `/api/buscar-clientes`
- Send limit parameter from clients page when fetching

## Testing
- `python -m py_compile app.py odoo_connection.py`


------
https://chatgpt.com/codex/tasks/task_b_68baf9b216c4832fa1614876a012631d