### PR TITLE
Handle Odoo 15 PDF report without deprecated xmlid_to_res_id

### DIFF
--- a/odoo_connection.py
+++ b/odoo_connection.py
@@ -411,24 +411,19 @@ class OdooConnection:
     def get_factura_pdf(self, factura_id):
         """Obtener el PDF de una factura"""
         try:
-            try:
-                _, report_id = self.models.execute_kw(
-                    self.db,
-                    self.uid,
-                    self.password,
-                    'ir.model.data',
-                    'xmlid_to_res_model_res_id',
-                    ['account.report_invoice'],
-                )
-            except Exception:
-                report_id = self.models.execute_kw(
-                    self.db,
-                    self.uid,
-                    self.password,
-                    'ir.model.data',
-                    'xmlid_to_res_id',
-                    ['account.report_invoice'],
-                )
+            # ``xmlid_to_res_model_res_id`` está disponible en Odoo 15 y
+            # devuelve una tupla ``(model, res_id)``. Usamos este método
+            # para obtener el identificador del reporte evitando el uso de
+            # ``xmlid_to_res_id``, retirado en versiones recientes.
+            _, report_id = self.models.execute_kw(
+                self.db,
+                self.uid,
+                self.password,
+                'ir.model.data',
+                'xmlid_to_res_model_res_id',
+                ['account.report_invoice'],
+            )
+
             pdf = self.models.execute_kw(
                 self.db,
                 self.uid,
@@ -437,6 +432,7 @@ class OdooConnection:
                 '_render_qweb_pdf',
                 [report_id, [factura_id]],
             )
+
             if isinstance(pdf, dict) and pdf.get('result'):
                 pdf_content = pdf['result']
             else:


### PR DESCRIPTION
## Summary
- Stop using deprecated `xmlid_to_res_id` when generating invoice PDFs
- Use `xmlid_to_res_model_res_id` to retrieve report id and add explanatory comments

## Testing
- `python -m py_compile app.py odoo_connection.py`

------
https://chatgpt.com/codex/tasks/task_b_68bafe5a6100832fa672f29bbac60b5a