### PR TITLE
Corrige cálculo del saldo a favor en clientes

### DIFF
--- a/odoo_connection.py
+++ b/odoo_connection.py
@@ -238,7 +238,7 @@ class OdooConnection:
 
                 credito = c.get('credit', 0.0)
                 debito = c.get('debit', 0.0)
-                saldo_favor = max(debito - credito, 0.0)
+                saldo_favor = max(credito - debito, 0.0)
                 clientes_formateados.append(
                     {
                         'id': c['id'],
@@ -295,7 +295,7 @@ class OdooConnection:
 
                 credito = c.get('credit', 0.0)
                 debito = c.get('debit', 0.0)
-                saldo_favor = max(debito - credito, 0.0)
+                saldo_favor = max(credito - debito, 0.0)
                 return {
                     'id': c.get('id'),
                     'nombre': c.get('name', ''),


### PR DESCRIPTION
## Resumen
- Corrige la fórmula para calcular el saldo a favor de los clientes, utilizando crédito menos débito.

## Pruebas
- `python -m py_compile app.py odoo_connection.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68baff9ab33c832fbe6649fc18caa6e7