### PR TITLE
Filtrar clientes principales por vendedor

### DIFF
--- a/odoo_connection.py
+++ b/odoo_connection.py
@@ -185,10 +185,15 @@ class OdooConnection:
         """Buscar clientes en Odoo.
 
         Solo se devolverán los clientes asignados al usuario indicado.
+        Se excluyen los contactos secundarios para evitar duplicados,
+        considerando únicamente los clientes principales.
         Se limita el número de resultados para evitar demoras al
         consultar grandes cantidades de registros."""
         try:
-            domain = [('customer_rank', '>', 0)]
+            domain = [
+                ('customer_rank', '>', 0),
+                ('parent_id', '=', False),
+            ]
             if nombre_cliente:
                 domain.append(('name', 'ilike', nombre_cliente))
             if user_id is not None:


### PR DESCRIPTION
## Summary
- Excluir contactos secundarios al buscar clientes para mostrar solo clientes principales

## Testing
- `python -m py_compile app.py odoo_connection.py`

------
https://chatgpt.com/codex/tasks/task_b_68bb13d96cfc832fbba67750d3687e70