### PR TITLE
Use image1 as favicon

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -5,6 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}App Vendedores{% endblock %}</title>
+    <link rel="icon" type="image/png" href="{{ url_for('static', filename='image1.png') }}">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.1.3/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
     <style>


### PR DESCRIPTION
## Summary
- Configure browser tab icon to use `image1.png` from the static folder

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_68bb214da45c832fb9d37e90b5608541