### PR TITLE
Use public report rendering method for invoice PDFs

### DIFF
--- a/odoo_connection.py
+++ b/odoo_connection.py
@@ -571,7 +571,7 @@ class OdooConnection:
                         self.uid,
                         self.password,
                         'ir.actions.report',
-                        '_render_qweb_pdf',
+                        'render_qweb_pdf',
                         [report_name, [factura_id]],
                     )
                     break
@@ -620,7 +620,7 @@ class OdooConnection:
                     self.uid,
                     self.password,
                     'ir.actions.report',
-                    '_render_qweb_pdf',
+                    'render_qweb_pdf',
                     [report_id, [factura_id]],
                 )
 


### PR DESCRIPTION
## Summary
- Replace private `_render_qweb_pdf` calls with public `render_qweb_pdf` when requesting invoice PDFs.

## Testing
- `python -m py_compile odoo_connection.py`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_b_68bb22e67f54832f993962327fe269c2