### PR TITLE
Add province and city filters for clients

### DIFF
--- a/app.py
+++ b/app.py
@@ -163,6 +163,36 @@ def buscar_facturas():
     except Exception as e:
         return jsonify({'error': str(e)}), 500
 
+@app.route('/api/provincias')
+def api_provincias():
+    if 'user_id' not in session:
+        return jsonify({'error': 'No autorizado'}), 401
+
+    try:
+        odoo = OdooConnection(ODOO_CONFIG['url'], ODOO_CONFIG['db'],
+                              session['username'], session['password'])
+        odoo.uid = session['user_id']
+        provincias = odoo.get_provincias()
+        return jsonify(provincias)
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+@app.route('/api/ciudades')
+def api_ciudades():
+    if 'user_id' not in session:
+        return jsonify({'error': 'No autorizado'}), 401
+
+    provincia_id = request.args.get('provincia_id', type=int)
+
+    try:
+        odoo = OdooConnection(ODOO_CONFIG['url'], ODOO_CONFIG['db'],
+                              session['username'], session['password'])
+        odoo.uid = session['user_id']
+        ciudades = odoo.get_ciudades(state_id=provincia_id, user_id=session['user_id'])
+        return jsonify(ciudades)
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
 @app.route('/api/buscar-clientes')
 def api_buscar_clientes():
     if 'user_id' not in session:
@@ -170,13 +200,21 @@ def api_buscar_clientes():
 
     nombre_cliente = request.args.get('nombre', '')
     limite = request.args.get('limite', 20)
+    provincia_id = request.args.get('provincia_id', type=int)
+    ciudad = request.args.get('ciudad', '')
 
     try:
         odoo = OdooConnection(ODOO_CONFIG['url'], ODOO_CONFIG['db'],
                               session['username'], session['password'])
         odoo.uid = session['user_id']
 
-        clientes = odoo.buscar_clientes(nombre_cliente, user_id=session['user_id'], limit=int(limite))
+        clientes = odoo.buscar_clientes(
+            nombre_cliente,
+            user_id=session['user_id'],
+            limit=int(limite),
+            provincia_id=provincia_id,
+            ciudad=ciudad
+        )
         return jsonify(clientes)
     except Exception as e:
         return jsonify({'error': str(e)}), 500

--- a/templates/clientes.html
+++ b/templates/clientes.html
@@ -19,11 +19,23 @@
         <!-- Búsqueda -->
         <div class="search-container">
             <div class="row g-3">
-                <div class="col-md-11">
+                <div class="col-md-4">
                     <label class="form-label fw-semibold">Buscar Cliente:</label>
                     <input type="text" class="form-control" id="buscarCliente" placeholder="Nombre del cliente...">
                 </div>
-                <div class="col-md-1 d-flex align-items-end">
+                <div class="col-md-3">
+                    <label class="form-label fw-semibold">Provincia:</label>
+                    <select id="filtroProvincia" class="form-select">
+                        <option value="">Todas</option>
+                    </select>
+                </div>
+                <div class="col-md-3">
+                    <label class="form-label fw-semibold">Ciudad:</label>
+                    <select id="filtroCiudad" class="form-select">
+                        <option value="">Todas</option>
+                    </select>
+                </div>
+                <div class="col-md-2 d-flex align-items-end">
                     <button class="btn btn-primary w-100" onclick="buscarClientes()">
                         <i class="fas fa-search"></i>
                     </button>
@@ -49,10 +61,14 @@
 <script>
 function buscarClientes() {
     const nombreCliente = document.getElementById('buscarCliente').value;
+    const provinciaId = document.getElementById('filtroProvincia').value;
+    const ciudad = document.getElementById('filtroCiudad').value;
     mostrarLoading();
     const params = new URLSearchParams();
     const limite = 20;
     if (nombreCliente) params.append('nombre', nombreCliente);
+    if (provinciaId) params.append('provincia_id', provinciaId);
+    if (ciudad) params.append('ciudad', ciudad);
     params.append('limite', limite);
     fetch(`/api/buscar-clientes?${params.toString()}`)
         .then(response => response.json())
@@ -110,7 +126,42 @@ document.getElementById('buscarCliente').addEventListener('input', function() {
     }, 500);
 });
 
+function cargarProvincias() {
+    fetch('/api/provincias')
+        .then(r => r.json())
+        .then(data => {
+            const select = document.getElementById('filtroProvincia');
+            select.innerHTML = '<option value="">Todas</option>' +
+                data.map(p => `<option value="${p.id}">${p.nombre}</option>`).join('');
+        })
+        .catch(err => console.error('Error cargando provincias', err));
+}
+
+function cargarCiudades() {
+    const provinciaId = document.getElementById('filtroProvincia').value;
+    const url = provinciaId ? `/api/ciudades?provincia_id=${provinciaId}` : '/api/ciudades';
+    fetch(url)
+        .then(r => r.json())
+        .then(data => {
+            const select = document.getElementById('filtroCiudad');
+            select.innerHTML = '<option value="">Todas</option>' +
+                data.map(c => `<option value="${c.nombre}">${c.nombre}</option>`).join('');
+        })
+        .catch(err => console.error('Error cargando ciudades', err));
+}
+
+document.getElementById('filtroProvincia').addEventListener('change', () => {
+    cargarCiudades();
+    buscarClientes();
+});
+
+document.getElementById('filtroCiudad').addEventListener('change', buscarClientes);
+
 // Cargar la lista de clientes al iniciar la página
-document.addEventListener('DOMContentLoaded', buscarClientes);
+document.addEventListener('DOMContentLoaded', () => {
+    cargarProvincias();
+    cargarCiudades();
+    buscarClientes();
+});
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add API routes to fetch provinces and cities from Odoo
- extend client search to filter by province and city
- update clients page with province and city dropdowns and dynamic loading

## Testing
- `python -B -m py_compile app.py odoo_connection.py`


------
https://chatgpt.com/codex/tasks/task_b_68bb30beb6d8832fb9289589eb6b9f10