### PR TITLE
Add share options on invoice detail page

### DIFF
--- a/templates/factura_detalle.html
+++ b/templates/factura_detalle.html
@@ -22,6 +22,9 @@
                 <a href="{{ url_for('descargar_factura_pdf', factura_id=factura.id) }}" class="btn btn-primary mt-3">
                     <i class="fas fa-download me-2"></i>Descargar PDF
                 </a>
+                <button type="button" class="btn btn-secondary mt-3" id="share-button">
+                    <i class="fas fa-share-alt me-2"></i>Compartir
+                </button>
             </div>
         </div>
 
@@ -53,4 +56,63 @@
         </div>
     </div>
 </div>
+<!-- Modal de opciones de compartir -->
+<div class="modal fade" id="shareModal" tabindex="-1" aria-labelledby="shareModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="shareModalLabel">Compartir factura</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <div class="d-grid gap-2">
+                    <a id="whatsappShare" class="btn btn-success" target="_blank">
+                        <i class="fab fa-whatsapp me-2"></i>WhatsApp
+                    </a>
+                    <a id="gmailShare" class="btn btn-danger" target="_blank">
+                        <i class="fas fa-envelope me-2"></i>Gmail
+                    </a>
+                    <a id="instagramShare" class="btn btn-warning" target="_blank">
+                        <i class="fab fa-instagram me-2"></i>Instagram
+                    </a>
+                    <button type="button" class="btn btn-primary" id="printButton">
+                        <i class="fas fa-print me-2"></i>Imprimir
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block extra_js %}
+{% set factura_url = url_for('factura_detalle', cliente_id=cliente_id, factura_id=factura.id, _external=True) %}
+<script>
+document.getElementById('share-button').addEventListener('click', function() {
+    const shareData = {
+        title: 'Factura {{ factura.nombre }}',
+        text: 'Factura {{ factura.nombre }} - Total ${{ "%.2f"|format(factura.total) }}',
+        url: '{{ factura_url }}'
+    };
+
+    if (navigator.share) {
+        navigator.share(shareData).catch(() => {
+            const modal = new bootstrap.Modal(document.getElementById('shareModal'));
+            modal.show();
+        });
+    } else {
+        const modal = new bootstrap.Modal(document.getElementById('shareModal'));
+        modal.show();
+    }
+});
+
+const facturaUrl = '{{ factura_url }}';
+document.getElementById('whatsappShare').href = `https://wa.me/?text=${encodeURIComponent(facturaUrl)}`;
+document.getElementById('gmailShare').href = `mailto:?subject=${encodeURIComponent('Factura ' + '{{ factura.nombre }}')}&body=${encodeURIComponent(facturaUrl)}`;
+document.getElementById('instagramShare').href = `https://www.instagram.com/?url=${encodeURIComponent(facturaUrl)}`;
+
+document.getElementById('printButton').addEventListener('click', function() {
+    window.print();
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add "Compartir" button and modal for invoice sharing
- enable sharing via WhatsApp, Gmail, Instagram, and print with Web Share API fallback

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_b_68bb39a6bb38832fa33fe54578bb4c1e