### PR TITLE
Ordenar clientes por mayor deuda

### DIFF
--- a/templates/clientes.html
+++ b/templates/clientes.html
@@ -96,6 +96,8 @@ function actualizarListaClientes(clientes) {
         `;
         return;
     }
+    // Ordenar de mayor a menor deuda antes de renderizar
+    clientes.sort((a, b) => b.deuda_total - a.deuda_total);
 
     lista.innerHTML = clientes.map(c => `
         <a href="/clientes/${c.id}" class="text-decoration-none text-dark">


### PR DESCRIPTION
## Summary
- Ordenar la lista de clientes de mayor a menor deuda antes de mostrarlos.

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_68bb3d2a60c0832fb66b4fa7b34b6059