### PR TITLE
Generate detailed invoice PDF

### DIFF
--- a/templates/factura_detalle.html
+++ b/templates/factura_detalle.html
@@ -37,7 +37,8 @@
                                 <th>Descripción</th>
                                 <th>Cantidad</th>
                                 <th>Precio Unitario</th>
-                                <th>Subtotal</th>
+                                <th>IVA 21%</th>
+                                <th>Total</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -46,7 +47,8 @@
                                 <td>{{ linea.descripcion }}</td>
                                 <td>{{ linea.cantidad }}</td>
                                 <td>${{ "%.2f"|format(linea.precio_unitario) }}</td>
-                                <td>${{ "%.2f"|format(linea.subtotal) }}</td>
+                                <td>${{ "%.2f"|format(linea.iva) }}</td>
+                                <td>${{ "%.2f"|format(linea.total) }}</td>
                             </tr>
                             {% endfor %}
                         </tbody>


### PR DESCRIPTION
## Summary
- Include tax summary and outstanding amount when retrieving invoice data
- Render invoice PDFs with line-item quantities, unit prices, IVA 21% and totals
- Display IVA and total columns on invoice detail page

## Testing
- `python -m py_compile app.py odoo_connection.py`


------
https://chatgpt.com/codex/tasks/task_b_68beccabeadc832fafc0349526d4b8be