### PR TITLE
Generate detailed invoice PDF

### DIFF
--- a/templates/factura_detalle.html
+++ b/templates/factura_detalle.html
@@ -37,7 +37,8 @@
                                 <th>Descripción</th>
                                 <th>Cantidad</th>
                                 <th>Precio Unitario</th>
-                                <th>Subtotal</th>
+                                <th>IVA 21%</th>
+                                <th>Total</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -46,7 +47,8 @@
                                 <td>{{ linea.descripcion }}</td>
                                 <td>{{ linea.cantidad }}</td>
                                 <td>${{ "%.2f"|format(linea.precio_unitario) }}</td>
-                                <td>${{ "%.2f"|format(linea.subtotal) }}</td>
+                                <td>${{ "%.2f"|format(linea.iva) }}</td>
+                                <td>${{ "%.2f"|format(linea.total) }}</td>
                             </tr>
                             {% endfor %}
                         </tbody>
@@ -90,11 +92,15 @@
 {% set pdf_url = url_for('descargar_factura_pdf', factura_id=factura.id, _external=True) %}
 <script>
 const pdfUrl = '{{ pdf_url }}';
-document.getElementById('share-button').addEventListener('click', async function() {
+document.getElementById('share-button').addEventListener('click', async () => {
     try {
-        const response = await fetch(pdfUrl);
+        const response = await fetch(pdfUrl, { credentials: 'include' });
+        if (!response.ok) throw new Error('No se pudo obtener el PDF');
+
         const blob = await response.blob();
-        const file = new File([blob], 'factura_{{ factura.id }}.pdf', { type: 'application/pdf' });
+        const file = new File([blob], 'factura_{{ factura.id }}.pdf', {
+            type: 'application/pdf'
+        });
 
         if (navigator.canShare && navigator.canShare({ files: [file] })) {
             await navigator.share({
@@ -102,11 +108,10 @@ document.getElementById('share-button').addEventListener('click', async function
                 text: 'Factura {{ factura.nombre }} - Total ${{ "%.2f"|format(factura.total) }}',
                 files: [file]
             });
-        } else {
-            throw new Error('Web Share API no soportado');
+            return;
         }
+        throw new Error('Web Share API no soportado');
     } catch (e) {
-
         const modal = new bootstrap.Modal(document.getElementById('shareModal'));
         modal.show();
     }


### PR DESCRIPTION
## Summary
- Include tax summary and outstanding amount when retrieving invoice data
- Render invoice PDFs with line-item quantities, unit prices, IVA 21% and totals
- Display IVA and total columns on invoice detail page
- Share the same PDF via Web Share API when pressing **Compartir**

## Testing
- `python -m py_compile app.py odoo_connection.py`


------
https://chatgpt.com/codex/tasks/task_b_68beccabeadc832fafc0349526d4b8be