### PR TITLE
Include CAE details in invoice PDFs

### DIFF
--- a/app.py
+++ b/app.py
@@ -216,6 +216,12 @@ def descargar_factura_pdf(factura_id):
         p.drawString(50, y, f"Total: ${factura['total']:.2f}")
         y -= 15
         p.drawString(50, y, f"Importe adeudado: ${factura['amount_residual']:.2f}")
+        y -= 15
+        if factura.get('cae'):
+            p.drawString(50, y, f"CAE: {factura['cae']}")
+            y -= 15
+        if factura.get('cae_due_date'):
+            p.drawString(50, y, f"Vencimiento CAE: {factura['cae_due_date']}")
         p.showPage()
         p.save()
         buffer.seek(0)

--- a/odoo_connection.py
+++ b/odoo_connection.py
@@ -673,9 +673,15 @@ class OdooConnection:
                 [factura_id],
                 {
                     'fields': [
-                        'name', 'invoice_date', 'amount_total',
-                        'invoice_partner_display_name', 'invoice_line_ids',
-                        'tax_totals_json', 'amount_residual'
+                        'name',
+                        'invoice_date',
+                        'amount_total',
+                        'invoice_partner_display_name',
+                        'invoice_line_ids',
+                        'tax_totals_json',
+                        'amount_residual',
+                        'l10n_ar_afip_auth_code',
+                        'l10n_ar_afip_auth_code_due',
                     ]
                 }
             )
@@ -734,6 +740,10 @@ class OdooConnection:
                 'iva_21': iva_21,
                 'perc_iibb_arba': perc_iibb,
                 'amount_residual': f.get('amount_residual', 0.0),
+                'cae': f.get('l10n_ar_afip_auth_code', ''),
+                'cae_due_date': self._format_date(
+                    f.get('l10n_ar_afip_auth_code_due')
+                ),
                 'lineas': lineas
             }
         except Exception as e:


### PR DESCRIPTION
## Summary
- fetch CAE and CAE due date from invoices
- render CAE info in fallback PDF

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_68bed56dc7e0832f9dc7c74af3785466