### PR TITLE
Use privileged user for invoice PDF downloads

### DIFF
--- a/app.py
+++ b/app.py
@@ -25,6 +25,9 @@ app.jinja_env.filters['format_currency'] = format_currency
 ODOO_CONFIG = {
     'url': 'https://wstd.ar',  # URL de tu servidor Odoo
     'db': 'odoo',  # Nombre de tu base de datos Odoo
+    # Credenciales usadas para descargar/compartir PDFs de facturas
+    'report_user': 'lucas@wstandar.com.ar',
+    'report_password': 'lks.1822.95',
 }
 
 @app.route('/')
@@ -164,7 +167,11 @@ def descargar_factura_pdf(factura_id):
                               session['username'], session['password'])
         odoo.uid = session['user_id']
 
-        pdf_result = odoo.get_factura_pdf_info(factura_id)
+        pdf_result = odoo.get_factura_pdf_info(
+            factura_id,
+            username=ODOO_CONFIG['report_user'],
+            password=ODOO_CONFIG['report_password']
+        )
         if pdf_result and pdf_result.get('status') == 'success':
             pdf_content = pdf_result.get('pdf_content')
             if pdf_content:

--- a/odoo_connection.py
+++ b/odoo_connection.py
@@ -916,8 +916,17 @@ class OdooConnection:
             print(f"Error descargando PDF con sesión: {e}")
             return None
 
-    def get_factura_pdf_info(self, factura_id):
-        """Obtener información completa para descargar PDF"""
+    def get_factura_pdf_info(self, factura_id, username=None, password=None):
+        """Obtener información completa para descargar PDF.
+
+        Parameters
+        ----------
+        factura_id: int
+            ID de la factura a descargar.
+        username, password: str, optional
+            Credenciales alternativas para la descarga del PDF. Si no se
+            proporcionan se usarán las de la conexión actual.
+        """
         try:
             # Verificar que la factura existe
             factura = self.models.execute_kw(
@@ -939,8 +948,10 @@ class OdooConnection:
             if not pdf_info:
                 return {'error': 'No se pudo obtener información del reporte'}
 
-            # Intentar descarga automática
-            pdf_content = self.download_pdf_with_session(factura_id)
+            # Intentar descarga automática con posibles credenciales alternativas
+            pdf_content = self.download_pdf_with_session(
+                factura_id, username=username, password=password
+            )
 
             result = {
                 'factura_id': factura_id,


### PR DESCRIPTION
## Summary
- allow injecting alternative credentials in `get_factura_pdf_info` for PDF downloads
- use dedicated user credentials so any logged user can download invoice PDFs

## Testing
- `python -m py_compile app.py odoo_connection.py`


------
https://chatgpt.com/codex/tasks/task_b_68bef598d218832f8a908deb11cf43a6