### PR TITLE
Filtrar clientes sin gasto en estadístico

### DIFF
--- a/odoo_connection.py
+++ b/odoo_connection.py
@@ -230,13 +230,15 @@ class OdooConnection:
                 total_cliente = self.get_total_gasto_cliente_mes(
                     p['id'], year, month
                 )
-                resultados.append({
-                    'id': p['id'],
-                    'nombre': p['name'],
-                    'total_mes': total_cliente
-                })
-                total_general += total_cliente
+                if total_cliente > 0:
+                    resultados.append({
+                        'id': p['id'],
+                        'nombre': p['name'],
+                        'total_mes': total_cliente
+                    })
+                    total_general += total_cliente
 
+            resultados.sort(key=lambda x: x['total_mes'], reverse=True)
             return resultados, total_general
         except Exception as e:
             print(f"Error obteniendo clientes por ubicación: {e}")


### PR DESCRIPTION
## Summary
- Excluye de los resultados de estadísticos a los clientes sin gasto mensual.
- Ordena los clientes filtrados de mayor a menor monto gastado.

## Testing
- `python -m py_compile app.py odoo_connection.py`
- `pytest -q --disable-warnings --maxfail=1 --ignore=venv`


------
https://chatgpt.com/codex/tasks/task_b_68c027f52494832faadd0179132aec2b