### PR TITLE
Enable sharing invoice PDFs directly

### DIFF
--- a/templates/factura_detalle.html
+++ b/templates/factura_detalle.html
@@ -25,6 +25,9 @@
                 <button type="button" class="btn btn-secondary mt-3" id="share-button">
                     <i class="fas fa-share-alt me-2"></i>Compartir
                 </button>
+                <button type="button" class="btn btn-secondary mt-3" id="print-button">
+                    <i class="fas fa-print me-2"></i>Imprimir
+                </button>
             </div>
         </div>
 
@@ -58,33 +61,6 @@
         </div>
     </div>
 </div>
-<!-- Modal de opciones de compartir -->
-<div class="modal fade" id="shareModal" tabindex="-1" aria-labelledby="shareModalLabel" aria-hidden="true">
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title" id="shareModalLabel">Compartir factura</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-            </div>
-            <div class="modal-body">
-                <div class="d-grid gap-2">
-                    <a id="whatsappShare" class="btn btn-success" target="_blank">
-                        <i class="fab fa-whatsapp me-2"></i>WhatsApp
-                    </a>
-                    <a id="gmailShare" class="btn btn-danger" target="_blank">
-                        <i class="fas fa-envelope me-2"></i>Gmail
-                    </a>
-                    <a id="instagramShare" class="btn btn-warning" target="_blank">
-                        <i class="fab fa-instagram me-2"></i>Instagram
-                    </a>
-                    <button type="button" class="btn btn-primary" id="printButton">
-                        <i class="fas fa-print me-2"></i>Imprimir
-                    </button>
-                </div>
-            </div>
-        </div>
-    </div>
-</div>
 {% endblock %}
 
 {% block extra_js %}
@@ -92,12 +68,19 @@
 {% set pdf_url = url_for('descargar_factura_pdf', factura_id=factura.id, _external=True) %}
 <script>
 const pdfUrl = '{{ pdf_url }}';
+let downloadedFile = null;
+
+async function fetchPdf() {
+    const response = await fetch(pdfUrl, { credentials: 'include' });
+    if (!response.ok) throw new Error('No se pudo obtener el PDF');
+    const blob = await response.blob();
+    downloadedFile = new File([blob], 'factura_{{ factura.id }}.pdf', { type: 'application/pdf' });
+    return blob;
+}
+
 document.getElementById('download-pdf').addEventListener('click', async () => {
     try {
-        const response = await fetch(pdfUrl, { credentials: 'include' });
-        if (!response.ok) throw new Error('No se pudo obtener el PDF');
-
-        const blob = await response.blob();
+        const blob = await fetchPdf();
         const url = window.URL.createObjectURL(blob);
         const a = document.createElement('a');
         a.href = url;
@@ -110,69 +93,31 @@ document.getElementById('download-pdf').addEventListener('click', async () => {
         console.error(err);
     }
 });
+
 document.getElementById('share-button').addEventListener('click', async () => {
     try {
-        const response = await fetch(pdfUrl, { credentials: 'include' });
-        if (!response.ok) throw new Error('No se pudo obtener el PDF');
-
-        const blob = await response.blob();
-        const file = new File([blob], 'factura_{{ factura.id }}.pdf', {
-            type: 'application/pdf'
-        });
-
-        if (navigator.canShare && navigator.canShare({ files: [file] })) {
+        if (!downloadedFile) {
+            await fetchPdf();
+        }
+        if (navigator.share && navigator.canShare && navigator.canShare({ files: [downloadedFile] })) {
             await navigator.share({
                 title: 'Factura {{ factura.nombre }}',
-                text: 'Factura {{ factura.nombre }} - Total ${{ factura.total|format_currency }}',
-                files: [file]
+                files: [downloadedFile]
             });
-            return;
+        } else {
+            throw new Error('Compartir archivos no soportado');
         }
-        throw new Error('Web Share API no soportado');
     } catch (e) {
-        const modal = new bootstrap.Modal(document.getElementById('shareModal'));
-        modal.show();
+        alert('Este navegador no soporta compartir archivos. Por favor, descargue el PDF y compártalo manualmente.');
     }
 });
-
-
-const whatsappShare = document.getElementById('whatsappShare');
-whatsappShare.href = `https://wa.me/?text=${encodeURIComponent(pdfUrl)}`;
-whatsappShare.addEventListener('click', async (e) => {
-    e.preventDefault();
-    try {
-        const response = await fetch(pdfUrl, { credentials: 'include' });
-        if (!response.ok) throw new Error('No se pudo obtener el PDF');
-
-        const blob = await response.blob();
-        const file = new File([blob], 'factura_{{ factura.id }}.pdf', {
-            type: 'application/pdf'
-        });
-
-        if (navigator.canShare && navigator.canShare({ files: [file] })) {
-            await navigator.share({
-                title: 'Factura {{ factura.nombre }}',
-                files: [file]
-            });
-            return;
-        }
-    } catch (err) {
-        // Si no se puede compartir el archivo, se sigue con el enlace
-    }
-    window.open(`https://wa.me/?text=${encodeURIComponent(pdfUrl)}`, '_blank');
-});
-
-document.getElementById('gmailShare').href = `mailto:?subject=${encodeURIComponent('Factura ' + '{{ factura.nombre }}')}&body=${encodeURIComponent(pdfUrl)}`;
-document.getElementById('instagramShare').href = `https://www.instagram.com/?url=${encodeURIComponent(pdfUrl)}`;
-
-document.getElementById('printButton').addEventListener('click', function() {
+document.getElementById('print-button').addEventListener('click', function() {
     const printWindow = window.open(pdfUrl, '_blank');
     if (printWindow) {
         printWindow.addEventListener('load', function() {
             printWindow.print();
         }, { once: true });
     }
-
 });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Remove per-app link fallback so invoices share only the downloaded PDF
- Add a dedicated print button separate from the share flow

## Testing
- `python -m py_compile app.py odoo_connection.py`


------
https://chatgpt.com/codex/tasks/task_b_68c06750a388832f9ea66b8990d3cbb0