### PR TITLE
Handle PDF share fallback when file sharing unsupported

### DIFF
--- a/templates/factura_detalle.html
+++ b/templates/factura_detalle.html
@@ -96,20 +96,28 @@ document.getElementById('download-pdf').addEventListener('click', async () => {
 
 document.getElementById('share-button').addEventListener('click', async () => {
     try {
-
-        if (!downloadedFile) {
-            await fetchPdf();
-        }
-        if (navigator.share && navigator.canShare && navigator.canShare({ files: [downloadedFile] })) {
+        if (navigator.share) {
+            if (navigator.canShare) {
+                if (!downloadedFile) {
+                    await fetchPdf();
+                }
+                if (navigator.canShare({ files: [downloadedFile] })) {
+                    await navigator.share({
+                        title: 'Factura {{ factura.nombre }}',
+                        files: [downloadedFile]
+                    });
+                    return;
+                }
+            }
             await navigator.share({
                 title: 'Factura {{ factura.nombre }}',
-                files: [downloadedFile]
+                url: pdfUrl
             });
         } else {
             throw new Error('Compartir archivos no soportado');
         }
     } catch (e) {
-        alert('Este navegador no soporta compartir archivos. Por favor, descargue el PDF y compártalo manualmente.');
+        alert('Este navegador no soporta la función de compartir. Por favor, descargue el PDF y compártalo manualmente.');
 
     }
 });


### PR DESCRIPTION
## Summary
- fall back to sharing PDF URL if the browser cannot share files

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_b_68c0705c5130832f9b3cefe621608999