### PR TITLE
Mostrar saldo a favor por compañía

### DIFF
--- a/app.py
+++ b/app.py
@@ -184,13 +184,14 @@ def cliente_detalle(cliente_id):
 
     mes = request.args.get('mes')
     return_url = request.args.get('return_url')
+    company_id = request.args.get('company_id', type=int)
 
     try:
         odoo = OdooConnection(ODOO_CONFIG['url'], ODOO_CONFIG['db'],
                               session['username'], session['password'])
         odoo.uid = session['user_id']
 
-        cliente_info = odoo.get_cliente(cliente_id)
+        cliente_info = odoo.get_cliente(cliente_id, company_id=company_id)
 
         if mes:
             try:

--- a/templates/clientes.html
+++ b/templates/clientes.html
@@ -130,8 +130,11 @@ function actualizarListaClientes(clientes) {
     // Ordenar de mayor a menor deuda antes de renderizar
     clientes.sort((a, b) => b.deuda_total - a.deuda_total);
 
+    const companiaElem = document.getElementById('filtroCompania');
+    const companyId = companiaElem ? companiaElem.value : '';
+
     lista.innerHTML = clientes.map(c => `
-        <a href="/clientes/${c.id}" class="text-decoration-none text-dark">
+        <a href="/clientes/${c.id}${companyId ? `?company_id=${companyId}` : ''}" class="text-decoration-none text-dark">
             <div class="card cliente-card">
                 <div class="card-body">
                     <h5 class="fw-bold text-primary">


### PR DESCRIPTION
## Summary
- Preservar la compañía seleccionada en los enlaces de cliente para mostrar datos correctos por empresa
- Consultar los detalles del cliente con el contexto de compañía seleccionado para obtener su saldo a favor correspondiente

## Testing
- `python -m py_compile app.py odoo_connection.py`


------
https://chatgpt.com/codex/tasks/task_b_68c07fcd1a3c832fa21270bdb16cb26d