### PR TITLE
Mostrar saldo a favor por compañía

### DIFF
--- a/app.py
+++ b/app.py
@@ -184,13 +184,14 @@ def cliente_detalle(cliente_id):
 
     mes = request.args.get('mes')
     return_url = request.args.get('return_url')
+    company_id = request.args.get('company_id', type=int)
 
     try:
         odoo = OdooConnection(ODOO_CONFIG['url'], ODOO_CONFIG['db'],
                               session['username'], session['password'])
         odoo.uid = session['user_id']
 
-        cliente_info = odoo.get_cliente(cliente_id)
+        cliente_info = odoo.get_cliente(cliente_id, company_id=company_id)
 
         if mes:
             try:

--- a/templates/cliente_detalle.html
+++ b/templates/cliente_detalle.html
@@ -27,12 +27,10 @@
                         <i class="fas fa-money-bill-wave me-2 text-danger"></i>
                         Deuda total: ${{ cliente.deuda_total|format_currency }}
                     </p>
-                    {% if cliente.saldo_favor > 0 %}
                     <p class="mb-1">
                         <i class="fas fa-coins me-2 text-success"></i>
-                        Saldo a favor: ${{ cliente.saldo_favor|format_currency }}
+                        Saldo a favor: {% if cliente.saldo_favor and cliente.saldo_favor > 0 %}${{ cliente.saldo_favor|format_currency }}{% else %}0{% endif %}
                     </p>
-                    {% endif %}
                     <p class="mb-1">
                         <i class="fas fa-shopping-cart me-2 text-info"></i>
                         Gastó: ${{ total_mes|format_currency }}

--- a/templates/clientes.html
+++ b/templates/clientes.html
@@ -130,8 +130,11 @@ function actualizarListaClientes(clientes) {
     // Ordenar de mayor a menor deuda antes de renderizar
     clientes.sort((a, b) => b.deuda_total - a.deuda_total);
 
+    const companiaElem = document.getElementById('filtroCompania');
+    const companyId = companiaElem ? companiaElem.value : '';
+
     lista.innerHTML = clientes.map(c => `
-        <a href="/clientes/${c.id}" class="text-decoration-none text-dark">
+        <a href="/clientes/${c.id}${companyId ? `?company_id=${companyId}` : ''}" class="text-decoration-none text-dark">
             <div class="card cliente-card">
                 <div class="card-body">
                     <h5 class="fw-bold text-primary">
@@ -141,11 +144,10 @@ function actualizarListaClientes(clientes) {
                         <i class="fas fa-money-bill-wave me-2 text-danger"></i>
                         Deuda total: $${c.deuda_total.toLocaleString('es-AR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
                     </p>
-                    ${c.saldo_favor > 0 ? `
                     <p class="mb-0">
                         <i class="fas fa-coins me-2 text-success"></i>
-                        Saldo a favor: $${c.saldo_favor.toLocaleString('es-AR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
-                    </p>` : ''}
+                        Saldo a favor: ${c.saldo_favor > 0 ? `$${c.saldo_favor.toLocaleString('es-AR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}` : '0'}
+                    </p>
                 </div>
             </div>
         </a>


### PR DESCRIPTION
## Summary
- Preservar la compañía seleccionada en los enlaces de cliente para mostrar datos correctos por empresa
- Consultar los detalles del cliente con el contexto de compañía seleccionado para obtener su saldo a favor correspondiente
- Restringir la consulta de crédito y deuda a la compañía seleccionada para evitar saldos acumulados
- Mostrar 0 cuando no hay saldo a favor

## Testing
- `python -m py_compile app.py odoo_connection.py`


------
https://chatgpt.com/codex/tasks/task_b_68c07fcd1a3c832fa21270bdb16cb26d