### PR TITLE
Fix invoice search and status filters ignoring month parameter

### DIFF
--- a/templates/cliente_detalle.html
+++ b/templates/cliente_detalle.html
@@ -137,7 +137,7 @@
 {% block extra_js %}
 <script>
 const CLIENTE_ID = {{ cliente.id }};
-const MES = "{{ mes }}";
+const MES = "{{ mes or '' }}";
 function buscarFacturasCliente() {
     const codigoFactura = document.getElementById('buscarFactura').value;
     const estadoFiltro = document.getElementById('filtroEstado').value;


### PR DESCRIPTION
## Summary
- Prevent month filter from defaulting to current month on client detail page
- Use empty month when not specified so searching and status filtering span all invoices

## Testing
- `python -m py_compile app.py odoo_connection.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c1634f3c40832fb99dfed79ab8f901