### PR TITLE
Allow Comercial user to filter by company

### DIFF
--- a/app.py
+++ b/app.py
@@ -101,7 +101,8 @@ def estadistico():
         odoo.uid = session['user_id']
         mostrar_todo = (
             odoo.has_group('sales_team.group_sale_manager') or
-            odoo.has_group('sales_team.group_sale_salesman_all_leads')
+            odoo.has_group('sales_team.group_sale_salesman_all_leads') or
+            session.get('user_name', '').lower() == 'comercial'
         )
 
         companias = odoo.get_companias() if mostrar_todo else []
@@ -166,7 +167,8 @@ def clientes():
         odoo.uid = session['user_id']
         mostrar_todo = (
             odoo.has_group('sales_team.group_sale_manager') or
-            odoo.has_group('sales_team.group_sale_salesman_all_leads')
+            odoo.has_group('sales_team.group_sale_salesman_all_leads') or
+            session.get('user_name', '').lower() == 'comercial'
         )
         companias = odoo.get_companias() if mostrar_todo else []
     except Exception:
@@ -393,7 +395,8 @@ def api_vendedores():
         odoo.uid = session['user_id']
         mostrar_todo = (
             odoo.has_group('sales_team.group_sale_manager') or
-            odoo.has_group('sales_team.group_sale_salesman_all_leads')
+            odoo.has_group('sales_team.group_sale_salesman_all_leads') or
+            session.get('user_name', '').lower() == 'comercial'
         )
         if not mostrar_todo:
             return jsonify([])
@@ -417,7 +420,8 @@ def api_ciudades():
         odoo.uid = session['user_id']
         mostrar_todo = (
             odoo.has_group('sales_team.group_sale_manager') or
-            odoo.has_group('sales_team.group_sale_salesman_all_leads')
+            odoo.has_group('sales_team.group_sale_salesman_all_leads') or
+            session.get('user_name', '').lower() == 'comercial'
         )
         user_id_param = None if mostrar_todo else session['user_id']
         if mostrar_todo and vendedor_id:
@@ -450,7 +454,8 @@ def api_buscar_clientes():
         odoo.uid = session['user_id']
         mostrar_todo = (
             odoo.has_group('sales_team.group_sale_manager') or
-            odoo.has_group('sales_team.group_sale_salesman_all_leads')
+            odoo.has_group('sales_team.group_sale_salesman_all_leads') or
+            session.get('user_name', '').lower() == 'comercial'
         )
 
         user_id_param = None if mostrar_todo else session['user_id']

--- a/odoo_connection.py
+++ b/odoo_connection.py
@@ -515,6 +515,8 @@ class OdooConnection:
                     ('customer_rank', '>', 0),
                     ('parent_id', '=', False)
                 ])
+            if company_id is not None:
+                domain.append(('company_id', '=', company_id))
 
             partners = self.models.execute_kw(
                 self.db,

--- a/templates/estadistico.html
+++ b/templates/estadistico.html
@@ -90,7 +90,7 @@
                             <tbody>
                                 {% for c in clientes %}
                                 <tr>
-                                    <td><a href="{{ url_for('cliente_detalle', cliente_id=c.id, mes=mes, return_url=request.full_path) }}">{{ c.nombre }}</a></td>
+                                    <td><a href="{{ url_for('cliente_detalle', cliente_id=c.id, mes=mes, return_url=request.full_path, company_id=company_id) }}">{{ c.nombre }}</a></td>
                                     <td class="text-end">$ {{ c.total_mes|format_currency }}</td>
                                 </tr>
                                 {% endfor %}


### PR DESCRIPTION
## Summary
- Permit user "Comercial" to access company filters on statistics and clients screens and related APIs
- Filter city lookup by company and preserve company parameter when opening client details from statistics view

## Testing
- `python -m py_compile app.py odoo_connection.py`


------
https://chatgpt.com/codex/tasks/task_b_68c1802b1d20832f99c1847234d3fdd5