### PR TITLE
feat: add month filter to clients view

### DIFF
--- a/app.py
+++ b/app.py
@@ -84,6 +84,7 @@ def estadistico():
     ciudad = request.args.get('ciudad', '')
     vendedor_id = request.args.get('vendedor_id', type=int)
     company_id = request.args.get('company_id', type=int)
+    mes = request.args.get('mes')
 
     try:
         if mes:
@@ -199,19 +200,24 @@ def cliente_detalle(cliente_id):
                 facturas = odoo.get_facturas_cliente_mes(
                     cliente_id, year, month, company_id=company_id
                 )
+                total_gastado = odoo.get_total_gasto_cliente_mes(
+                    cliente_id, year, month, company_id=company_id
+                )
             except ValueError:
-                # Si el parámetro es inválido, se muestran todas las facturas
-                facturas = odoo.get_facturas_cliente(cliente_id, company_id=company_id)
-
-                now = datetime.now()
-                year, month = now.year, now.month
+                facturas = odoo.get_facturas_cliente(
+                    cliente_id, company_id=company_id
+                )
+                total_gastado = odoo.get_total_gasto_cliente(
+                    cliente_id, company_id=company_id
+                )
                 mes_param = ''
         else:
-            facturas = odoo.get_facturas_cliente(cliente_id, company_id=company_id)
-            now = datetime.now()
-            year, month = now.year, now.month
-
-        total_gastado = odoo.get_total_gasto_cliente(cliente_id, company_id=company_id)
+            facturas = odoo.get_facturas_cliente(
+                cliente_id, company_id=company_id
+            )
+            total_gastado = odoo.get_total_gasto_cliente(
+                cliente_id, company_id=company_id
+            )
 
         return render_template(
             'cliente_detalle.html',
@@ -234,6 +240,7 @@ def factura_detalle(cliente_id, factura_id):
         return redirect(url_for('login'))
 
     company_id = request.args.get('company_id', type=int)
+    mes = request.args.get('mes')
 
     try:
         odoo = OdooConnection(ODOO_CONFIG['url'], ODOO_CONFIG['db'],
@@ -243,12 +250,12 @@ def factura_detalle(cliente_id, factura_id):
         factura = odoo.get_factura(factura_id)
         if not factura:
             flash('Factura no encontrada', 'error')
-            return redirect(url_for('cliente_detalle', cliente_id=cliente_id, company_id=company_id))
+            return redirect(url_for('cliente_detalle', cliente_id=cliente_id, company_id=company_id, mes=mes))
 
-        return render_template('factura_detalle.html', factura=factura, cliente_id=cliente_id, company_id=company_id)
+        return render_template('factura_detalle.html', factura=factura, cliente_id=cliente_id, company_id=company_id, mes=mes)
     except Exception as e:
         flash(f'Error al cargar factura: {str(e)}', 'error')
-        return redirect(url_for('cliente_detalle', cliente_id=cliente_id, company_id=company_id))
+        return redirect(url_for('cliente_detalle', cliente_id=cliente_id, company_id=company_id, mes=mes))
 
 @app.route('/facturas/<int:factura_id>/pdf')
 def descargar_factura_pdf(factura_id):
@@ -453,6 +460,7 @@ def api_buscar_clientes():
     vendedor_id = request.args.get('vendedor_id', type=int)
     adeudados = request.args.get('adeudados')
     company_id = request.args.get('company_id', type=int)
+    mes = request.args.get('mes')
 
     try:
         odoo = OdooConnection(ODOO_CONFIG['url'], ODOO_CONFIG['db'],
@@ -474,6 +482,21 @@ def api_buscar_clientes():
             ciudad=ciudad,
             company_id=company_id,
         )
+        if mes:
+            try:
+                year, month = map(int, mes.split('-'))
+                clientes_mes, _ = odoo.get_clientes_por_ubicacion_mes(
+                    year,
+                    month,
+                    provincia_id=provincia_id,
+                    ciudad=ciudad,
+                    user_id=user_id_param,
+                    company_id=company_id,
+                )
+                ids_mes = {c['id'] for c in clientes_mes}
+                clientes = [c for c in clientes if c['id'] in ids_mes]
+            except ValueError:
+                pass
         if adeudados:
             clientes = [c for c in clientes if c.get('deuda_total', 0) > 0]
         clientes.sort(key=lambda c: c.get('deuda_total', 0), reverse=True)

--- a/odoo_connection.py
+++ b/odoo_connection.py
@@ -190,7 +190,7 @@ class OdooConnection:
             print(f"Error obteniendo total mensual: {e}")
             return 0.0
 
-    def get_total_gasto_cliente_mes(self, partner_id, year, month):
+    def get_total_gasto_cliente_mes(self, partner_id, year, month, company_id=None):
         """Obtener el total pagado por un cliente en un mes específico.
 
         Incluye los montos abonados de manera parcial en cada factura.
@@ -206,6 +206,8 @@ class OdooConnection:
                 ('invoice_date', '>=', start_date),
                 ('invoice_date', '<=', end_date),
             ]
+            if company_id is not None:
+                domain.append(('company_id', '=', company_id))
             facturas_ids = self.models.execute_kw(
                 self.db, self.uid, self.password,
                 'account.move', 'search', [domain]

--- a/templates/cliente_detalle.html
+++ b/templates/cliente_detalle.html
@@ -61,11 +61,11 @@
         <!-- Búsqueda y Filtros -->
         <div class="search-container">
             <div class="row g-3">
-                <div class="col-md-6">
+                <div class="col-md-4">
                     <label class="form-label fw-semibold">Buscar Factura:</label>
                     <input type="text" class="form-control" id="buscarFactura" placeholder="Código de factura...">
                 </div>
-                <div class="col-md-4">
+                <div class="col-md-3">
                     <label class="form-label fw-semibold">Filtrar por Estado:</label>
                     <select class="form-select" id="filtroEstado">
                         <option value="">Todos los estados</option>
@@ -73,6 +73,10 @@
                         <option value="partial">Pagadas parcialmente</option>
                         <option value="paid">Pagadas</option>
                     </select>
+                </div>
+                <div class="col-md-3">
+                    <label class="form-label fw-semibold">Mes:</label>
+                    <input type="month" class="form-control" id="filtroMes" value="{{ mes }}">
                 </div>
                 <div class="col-md-2 d-flex align-items-end">
                     <button class="btn btn-primary w-100" onclick="buscarFacturasCliente()">
@@ -109,7 +113,7 @@
                                 {% for factura in facturas %}
                                 <tr>
                                     <td class="fw-bold">
-                                        <a href="{{ url_for('factura_detalle', cliente_id=cliente.id, factura_id=factura.id, company_id=company_id) }}" class="text-decoration-none">
+                                        <a href="{{ url_for('factura_detalle', cliente_id=cliente.id, factura_id=factura.id, company_id=company_id, mes=mes or None) }}" class="text-decoration-none">
                                             {{ factura.nombre }}
                                         </a>
                                     </td>
@@ -139,16 +143,16 @@
 {% block extra_js %}
 <script>
 const CLIENTE_ID = {{ cliente.id }};
-const MES = "{{ mes or '' }}";
 const COMPANY_ID = {{ company_id if company_id is not none else 'null' }};
 function buscarFacturasCliente() {
     const codigoFactura = document.getElementById('buscarFactura').value;
     const estadoFiltro = document.getElementById('filtroEstado').value;
+    const mes = document.getElementById('filtroMes').value;
     mostrarLoading();
     const params = new URLSearchParams();
     if (codigoFactura) params.append('codigo', codigoFactura);
     if (estadoFiltro) params.append('estado', estadoFiltro);
-    if (MES) params.append('mes', MES);
+    if (mes) params.append('mes', mes);
     if (COMPANY_ID) params.append('company_id', COMPANY_ID);
     fetch(`/api/cliente/${CLIENTE_ID}/facturas?${params.toString()}`)
         .then(response => response.json())
@@ -177,9 +181,14 @@ function actualizarTablaFacturas(facturas) {
         return;
     }
 
+    const mes = document.getElementById('filtroMes').value;
+    const linkParams = new URLSearchParams();
+    if (COMPANY_ID) linkParams.append('company_id', COMPANY_ID);
+    if (mes) linkParams.append('mes', mes);
+
     tbody.innerHTML = facturas.map(factura => `
         <tr>
-            <td class="fw-bold"><a href="/clientes/${CLIENTE_ID}/factura/${factura.id}${COMPANY_ID ? `?company_id=${COMPANY_ID}` : ''}" class="text-decoration-none">${factura.nombre}</a></td>
+            <td class="fw-bold"><a href="/clientes/${CLIENTE_ID}/factura/${factura.id}${linkParams.toString() ? `?${linkParams.toString()}` : ''}" class="text-decoration-none">${factura.nombre}</a></td>
             <td>${factura.fecha}</td>
             <td class="fw-semibold text-success">${factura.total.toLocaleString('es-AR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
             <td class="fw-semibold text-warning">${factura.pendiente.toLocaleString('es-AR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
@@ -196,5 +205,6 @@ document.getElementById('buscarFactura').addEventListener('input', function() {
 });
 
 document.getElementById('filtroEstado').addEventListener('change', buscarFacturasCliente);
+document.getElementById('filtroMes').addEventListener('change', buscarFacturasCliente);
 </script>
 {% endblock %}

--- a/templates/clientes.html
+++ b/templates/clientes.html
@@ -32,6 +32,10 @@
                         {% endfor %}
                     </select>
                 </div>
+                <div class="col-md-2">
+                    <label class="form-label fw-semibold">Mes:</label>
+                    <input type="month" class="form-control" id="filtroMes">
+                </div>
                 {% if mostrar_todo %}
                 <div class="col-md-2">
                     <label class="form-label fw-semibold">Comercial:</label>
@@ -90,6 +94,7 @@ function buscarClientes() {
     const vendedorId = vendedorElem ? vendedorElem.value : '';
     const companiaElem = document.getElementById('filtroCompania');
     const companyId = companiaElem ? companiaElem.value : '';
+    const mes = document.getElementById('filtroMes').value;
     const adeudados = document.getElementById('filtroAdeudados').checked;
     mostrarLoading();
     const params = new URLSearchParams();
@@ -99,6 +104,7 @@ function buscarClientes() {
     if (ciudad) params.append('ciudad', ciudad);
     if (vendedorId) params.append('vendedor_id', vendedorId);
     if (companyId) params.append('company_id', companyId);
+    if (mes) params.append('mes', mes);
     params.append('limite', limite);
     if (adeudados) params.append('adeudados', '1');
     fetch(`/api/buscar-clientes?${params.toString()}`)
@@ -132,9 +138,17 @@ function actualizarListaClientes(clientes) {
 
     const companiaElem = document.getElementById('filtroCompania');
     const companyId = companiaElem ? companiaElem.value : '';
+    const mes = document.getElementById('filtroMes').value;
+    const linkParams = new URLSearchParams();
+    if (mes) linkParams.append('mes', mes);
+    if (companyId) linkParams.append('company_id', companyId);
+    const returnUrl = `/clientes${linkParams.toString() ? `?${linkParams.toString()}` : ''}`;
+    const detailParams = new URLSearchParams(linkParams.toString());
+    detailParams.append('return_url', returnUrl);
+    const queryStr = detailParams.toString();
 
     lista.innerHTML = clientes.map(c => `
-        <a href="/clientes/${c.id}${companyId ? `?company_id=${companyId}` : ''}" class="text-decoration-none text-dark">
+        <a href="/clientes/${c.id}${queryStr ? `?${queryStr}` : ''}" class="text-decoration-none text-dark">
             <div class="card cliente-card">
                 <div class="card-body">
                     <h5 class="fw-bold text-primary">
@@ -214,6 +228,7 @@ document.getElementById('filtroProvincia').addEventListener('change', () => {
 
 document.getElementById('filtroCiudad').addEventListener('change', buscarClientes);
 document.getElementById('filtroAdeudados').addEventListener('change', buscarClientes);
+document.getElementById('filtroMes').addEventListener('change', buscarClientes);
 
 const vendedorElem = document.getElementById('filtroVendedor');
 if (vendedorElem) {
@@ -232,6 +247,9 @@ if (companiaElem) {
 
 // Cargar la lista de clientes al iniciar la página
 document.addEventListener('DOMContentLoaded', () => {
+    const mesElem = document.getElementById('filtroMes');
+    const now = new Date().toISOString().slice(0, 7);
+    mesElem.value = now;
     cargarProvincias();
     if (document.getElementById('filtroVendedor')) {
         cargarVendedores();

--- a/templates/factura_detalle.html
+++ b/templates/factura_detalle.html
@@ -9,7 +9,7 @@
             <h3 class="fw-bold text-white">
                 <i class="fas fa-file-invoice-dollar me-2"></i>Factura {{ factura.nombre }}
             </h3>
-            <a href="{{ url_for('cliente_detalle', cliente_id=cliente_id, company_id=company_id) }}" class="btn btn-outline-light">
+            <a href="{{ url_for('cliente_detalle', cliente_id=cliente_id, company_id=company_id, mes=mes or None) }}" class="btn btn-outline-light">
                 <i class="fas fa-arrow-left me-2"></i>Volver
             </a>
         </div>


### PR DESCRIPTION
## Summary
- allow filtering clients by selected month
- update client search API to filter by month
- include month selection in clients page
- add month filter to client detail and forward month to invoice view
- show monthly spending total in client detail when month filter is applied

## Testing
- `python -m py_compile app.py odoo_connection.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68c192ed700c832f8fafafdf749ee28c