### PR TITLE
Add paid amount column to client invoices

### DIFF
--- a/odoo_connection.py
+++ b/odoo_connection.py
@@ -841,7 +841,7 @@ class OdooConnection:
                 {
                     'fields': [
                         'name', 'invoice_date', 'amount_total', 'amount_residual',
-                        'payment_state'
+                        'payment_state', 'invoice_payments_widget'
                     ]
                 }
             )
@@ -851,11 +851,25 @@ class OdooConnection:
                 estado_pago = self._get_payment_state(factura)
                 if estado_filtro and estado_pago != estado_filtro:
                     continue
+
+                pagado = 0.0
+                widget = factura.get('invoice_payments_widget')
+                try:
+                    if widget:
+                        data = json.loads(widget) if isinstance(widget, str) else widget
+                        for p in data.get('content', []):
+                            pagado += p.get('amount', 0.0) or 0.0
+                except Exception:
+                    pagado = factura.get('amount_total', 0.0) - factura.get('amount_residual', 0.0)
+                if not widget:
+                    pagado = factura.get('amount_total', 0.0) - factura.get('amount_residual', 0.0)
+
                 facturas_formateadas.append({
                     'id': factura['id'],
                     'nombre': factura['name'],
                     'fecha': self._format_date(factura.get('invoice_date')),
                     'total': factura['amount_total'],
+                    'pagado': pagado,
                     'pendiente': factura['amount_residual'],
                     'estado': estado_pago,
                     'estado_texto': self.get_estado_texto(estado_pago),
@@ -899,7 +913,7 @@ class OdooConnection:
                 {
                     'fields': [
                         'name', 'invoice_date', 'amount_total', 'amount_residual',
-                        'payment_state'
+                        'payment_state', 'invoice_payments_widget'
                     ]
                 }
             )
@@ -909,11 +923,25 @@ class OdooConnection:
                 estado_pago = self._get_payment_state(factura)
                 if estado_filtro and estado_pago != estado_filtro:
                     continue
+
+                pagado = 0.0
+                widget = factura.get('invoice_payments_widget')
+                try:
+                    if widget:
+                        data = json.loads(widget) if isinstance(widget, str) else widget
+                        for p in data.get('content', []):
+                            pagado += p.get('amount', 0.0) or 0.0
+                except Exception:
+                    pagado = factura.get('amount_total', 0.0) - factura.get('amount_residual', 0.0)
+                if not widget:
+                    pagado = factura.get('amount_total', 0.0) - factura.get('amount_residual', 0.0)
+
                 facturas_formateadas.append({
                     'id': factura['id'],
                     'nombre': factura['name'],
                     'fecha': self._format_date(factura.get('invoice_date')),
                     'total': factura['amount_total'],
+                    'pagado': pagado,
                     'pendiente': factura['amount_residual'],
                     'estado': estado_pago,
                     'estado_texto': self.get_estado_texto(estado_pago),

--- a/templates/cliente_detalle.html
+++ b/templates/cliente_detalle.html
@@ -102,6 +102,7 @@
                                 <th>Factura</th>
                                 <th>Fecha</th>
                                 <th>Total</th>
+                                <th>Pagado</th>
                                 <th>Pendiente</th>
                                 <th>Estado</th>
                             </tr>
@@ -117,13 +118,14 @@
                                     </td>
                                     <td>{{ factura.fecha }}</td>
                                     <td class="fw-semibold text-success">${{ factura.total|format_currency }}</td>
+                                    <td class="fw-semibold text-primary">${{ factura.pagado|format_currency }}</td>
                                     <td class="fw-semibold text-warning">${{ factura.pendiente|format_currency }}</td>
                                     <td><span class="badge bg-{{ factura.estado_color }}">{{ factura.estado_texto }}</span></td>
                                 </tr>
                                 {% endfor %}
                             {% else %}
                                 <tr>
-                                    <td colspan="5" class="text-center text-muted py-4">
+                                    <td colspan="6" class="text-center text-muted py-4">
                                         <i class="fas fa-inbox fa-3x mb-3 d-block"></i>
                                         No hay facturas
                                     </td>
@@ -171,7 +173,7 @@ function actualizarTablaFacturas(facturas) {
     if (facturas.length === 0) {
         tbody.innerHTML = `
             <tr>
-                <td colspan="5" class="text-center text-muted py-4">
+                <td colspan="6" class="text-center text-muted py-4">
                     <i class="fas fa-search fa-3x mb-3 d-block"></i>
                     No se encontraron facturas con los criterios especificados
                 </td>
@@ -190,6 +192,7 @@ function actualizarTablaFacturas(facturas) {
             <td class="fw-bold"><a href="/clientes/${CLIENTE_ID}/factura/${factura.id}${linkParams.toString() ? `?${linkParams.toString()}` : ''}" class="text-decoration-none">${factura.nombre}</a></td>
             <td>${factura.fecha}</td>
             <td class="fw-semibold text-success">${factura.total.toLocaleString('es-AR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
+            <td class="fw-semibold text-primary">${factura.pagado.toLocaleString('es-AR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
             <td class="fw-semibold text-warning">${factura.pendiente.toLocaleString('es-AR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
             <td><span class="badge bg-${factura.estado_color}">${factura.estado_texto}</span></td>
         </tr>


### PR DESCRIPTION
## Summary
- show paid amount for each invoice in client detail view
- read `invoice_payments_widget` from Odoo and compute `pagado`

## Testing
- `python -m py_compile app.py odoo_connection.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68c1be9a0854832fae55613486ff131e